### PR TITLE
Reorganize key names

### DIFF
--- a/js/admin/src/main.js
+++ b/js/admin/src/main.js
@@ -6,7 +6,7 @@ app.initializers.add('lock', () => {
   extend(PermissionGrid.prototype, 'moderateItems', items => {
     items.add('lock', {
       icon: 'lock',
-      label: 'Lock discussions',
+      label: app.translator.trans('flarum-lock.admin.permissions.lock_discussions_label'),
       permission: 'discussion.lock'
     }, 95);
   });

--- a/js/forum/src/addLockBadge.js
+++ b/js/forum/src/addLockBadge.js
@@ -7,7 +7,7 @@ export default function addLockBadge() {
     if (this.isLocked()) {
       badges.add('locked', Badge.component({
         type: 'locked',
-        label: app.translator.trans('flarum-lock.forum.locked'),
+        label: app.translator.trans('flarum-lock.forum.badge.locked'),
         icon: 'lock'
       }));
     }

--- a/js/forum/src/addLockControl.js
+++ b/js/forum/src/addLockControl.js
@@ -7,7 +7,7 @@ export default function addLockControl() {
   extend(DiscussionControls, 'moderationControls', function(items, discussion) {
     if (discussion.canLock()) {
       items.add('lock', Button.component({
-        children: app.translator.trans(discussion.isLocked() ? 'flarum-lock.forum.unlock' : 'flarum-lock.forum.lock'),
+        children: app.translator.trans(discussion.isLocked() ? 'flarum-lock.forum.discussion_controls.unlock' : 'flarum-lock.forum.discussion_controls.lock'),
         icon: 'lock',
         onclick: this.lockAction.bind(discussion)
       }));

--- a/js/forum/src/components/DiscussionLockedNotification.js
+++ b/js/forum/src/components/DiscussionLockedNotification.js
@@ -12,6 +12,6 @@ export default class DiscussionLockedNotification extends Notification {
   }
 
   content() {
-    return app.translator.trans('flarum-lock.forum.discussion_locked_notification', {user: this.props.notification.sender()});
+    return app.translator.trans('flarum-lock.forum.notifications.discussion_locked_text', {user: this.props.notification.sender()});
   }
 }

--- a/js/forum/src/components/DiscussionLockedPost.js
+++ b/js/forum/src/components/DiscussionLockedPost.js
@@ -9,7 +9,7 @@ export default class DiscussionLockedPost extends EventPost {
 
   descriptionKey() {
     return this.props.post.content().locked
-      ? 'flarum-lock.forum.discussion_locked_post'
-      : 'flarum-lock.forum.discussion_unlocked_post';
+      ? 'flarum-lock.forum.post_stream.discussion_locked_post'
+      : 'flarum-lock.forum.post_stream.discussion_unlocked_post';
   }
 }

--- a/js/forum/src/main.js
+++ b/js/forum/src/main.js
@@ -23,7 +23,7 @@ app.initializers.add('flarum-lock', () => {
     items.add('discussionLocked', {
       name: 'discussionLocked',
       icon: 'lock',
-      label: app.translator.trans('flarum-lock.forum.notify_discussion_locked')
+      label: app.translator.trans('flarum-lock.forum.settings.notify_discussion_locked_label')
     });
   });
 });


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).
- Adjusts key names to three-tier namespacing.
- Extracts previously unextracted strings.
