### PR TITLE
Rename the key for the "Locked" badge tooltip

### DIFF
--- a/js/forum/src/addLockBadge.js
+++ b/js/forum/src/addLockBadge.js
@@ -7,7 +7,7 @@ export default function addLockBadge() {
     if (this.isLocked()) {
       badges.add('locked', Badge.component({
         type: 'locked',
-        label: app.translator.trans('flarum-lock.forum.badge.locked_discussion_tooltip'),
+        label: app.translator.trans('flarum-lock.forum.badge.locked_tooltip'),
         icon: 'lock'
       }));
     }


### PR DESCRIPTION
- Shortens the key name for consistency with `badge:` namespace.
- Revised YAML to follow.
