### PR TITLE
Use Full Icon Class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "flarum-extension": {
             "title": "Lock",
             "icon": {
-                "name": "lock",
+                "name": "fa fa-lock",
                 "backgroundColor": "#ddd",
                 "color": "#666"
             }

--- a/js/admin/src/main.js
+++ b/js/admin/src/main.js
@@ -5,7 +5,7 @@ import PermissionGrid from 'flarum/components/PermissionGrid';
 app.initializers.add('lock', () => {
   extend(PermissionGrid.prototype, 'moderateItems', items => {
     items.add('lock', {
-      icon: 'lock',
+      icon: 'fa fa-lock',
       label: app.translator.trans('flarum-lock.admin.permissions.lock_discussions_label'),
       permission: 'discussion.lock'
     }, 95);

--- a/js/forum/src/addLockBadge.js
+++ b/js/forum/src/addLockBadge.js
@@ -8,7 +8,7 @@ export default function addLockBadge() {
       badges.add('locked', Badge.component({
         type: 'locked',
         label: app.translator.trans('flarum-lock.forum.badge.locked_tooltip'),
-        icon: 'lock'
+        icon: 'fa fa-lock'
       }));
     }
   });

--- a/js/forum/src/addLockControl.js
+++ b/js/forum/src/addLockControl.js
@@ -8,7 +8,7 @@ export default function addLockControl() {
     if (discussion.canLock()) {
       items.add('lock', Button.component({
         children: app.translator.trans(discussion.isLocked() ? 'flarum-lock.forum.discussion_controls.unlock_button' : 'flarum-lock.forum.discussion_controls.lock_button'),
-        icon: 'lock',
+        icon: 'fa fa-lock',
         onclick: this.lockAction.bind(discussion)
       }));
     }

--- a/js/forum/src/components/DiscussionLockedNotification.js
+++ b/js/forum/src/components/DiscussionLockedNotification.js
@@ -2,7 +2,7 @@ import Notification from 'flarum/components/Notification';
 
 export default class DiscussionLockedNotification extends Notification {
   icon() {
-    return 'lock';
+    return 'fa fa-lock';
   }
 
   href() {

--- a/js/forum/src/components/DiscussionLockedPost.js
+++ b/js/forum/src/components/DiscussionLockedPost.js
@@ -3,8 +3,8 @@ import EventPost from 'flarum/components/EventPost';
 export default class DiscussionLockedPost extends EventPost {
   icon() {
     return this.props.post.content().locked
-      ? 'lock'
-      : 'unlock';
+      ? 'fa fa-lock'
+      : 'fa fa-unlock';
   }
 
   descriptionKey() {

--- a/js/forum/src/main.js
+++ b/js/forum/src/main.js
@@ -22,7 +22,7 @@ app.initializers.add('flarum-lock', () => {
   extend(NotificationGrid.prototype, 'notificationTypes', function (items) {
     items.add('discussionLocked', {
       name: 'discussionLocked',
-      icon: 'lock',
+      icon: 'fa fa-lock',
       label: app.translator.trans('flarum-lock.forum.settings.notify_discussion_locked_label')
     });
   });


### PR DESCRIPTION
Added `fa fa-` to wherever needed `fa fa-`.
This is because https://github.com/flarum/core/pull/1372 has removed `fa fa-`.