### PR TITLE
Fix reply on locked thread when there is a custom permissions

### DIFF
--- a/src/Listener/AddDiscussionLockedAttributes.php
+++ b/src/Listener/AddDiscussionLockedAttributes.php
@@ -20,6 +20,8 @@ class AddDiscussionLockedAttributes
     {
         if ($event->isSerializer(DiscussionSerializer::class)) {
             $event->attributes['isLocked'] = (bool) $event->model->is_locked;
+            $event->attributes['canReply'] = $event->attributes['isLocked'] === true
+                ? (bool) $event->actor->can('lock', $event->model) : true;
             $event->attributes['canLock'] = (bool) $event->actor->can('lock', $event->model);
         }
     }

--- a/src/Listener/AddDiscussionLockedAttributes.php
+++ b/src/Listener/AddDiscussionLockedAttributes.php
@@ -20,8 +20,9 @@ class AddDiscussionLockedAttributes
     {
         if ($event->isSerializer(DiscussionSerializer::class)) {
             $event->attributes['isLocked'] = (bool) $event->model->is_locked;
-            $event->attributes['canReply'] = $event->attributes['isLocked'] === true
-                ? (bool) $event->actor->can('lock', $event->model) : true;
+            $event->attributes['canReply'] =
+                ($event->attributes['canReply'] === true && $event->attributes['isLocked'] === true)
+                ? (bool) $event->actor->can('lock', $event->model) : $event->attributes['canReply'];
             $event->attributes['canLock'] = (bool) $event->actor->can('lock', $event->model);
         }
     }


### PR DESCRIPTION
Currently users can post reply on locked thread when there is a custom permission for specific tag discussions. 